### PR TITLE
Add kata reverted-merge

### DIFF
--- a/Overview.md
+++ b/Overview.md
@@ -34,6 +34,9 @@ A basic merge between diverging branches with incompatible changesets.
 ## [merge-mergesort](merge-mergesort/README.md)
 A merge confligt with actual code.
 
+## [reverted-merge](reverted-merge/README.md)
+A merge has to be reverted, but this causes problems.
+
 ## [rebase-branch](rebase-branch/README.md)
 Using rebase as an alternative to merging.
 
@@ -44,7 +47,7 @@ A quick exercise in using Git hooks.
 We might have created our commits in a suboptimal order, practice to fix that scenario here.
 
 ## [reset](reset/README.md)
-Reset is a powerful and slightly dangerous command if you do not know what you are doing. 
+Reset is a powerful and slightly dangerous command if you do not know what you are doing.
 Go trough the three modes of resetting here.
 
 ## [basic-stashing](basic-stashing/README.md)

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -1,0 +1,3 @@
+# Git Kata: Reverted merge
+
+## The task

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -14,7 +14,8 @@ has to be fixed by this other team. To prevent the bug from being released into
 production, you decide to revert the merge commit.
 
 ## The task
-* Revert the merge commit
+* Revert the merge commit  
+  *Note: You may assume that feature Y is also working with the old library version*
 * Take the role of the library team and fix the bug in the library on the branch
 * Explore how you can get the changes from the branch into the master again  
   Try to merge first to see what happens

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -11,9 +11,15 @@ prudent, you do this on a branch `integrate-library-1.2.4`.
 
 Unfortunately, you discover after your merge that the library has a bug, which
 has to be fixed by this other team. To prevent from releasing it into production,
-you revert the merge commit.
+you decide to revert the merge commit.
 
 ## The task
-* Take the role of the library team and fix the bug on the branch
+* Revert the merge commit
+* Take the role of the library team and fix the bug in the library on the branch
 * Explore how you can get the changes from the branch into the master again  
   Try to merge first to see what happens
+
+## Useful commands
+* `git revert`
+* `git rebase`
+* `git merge`

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -10,8 +10,8 @@ At some point, your team integrates a new version library-1.2.4. Because you are
 prudent, you do this on a branch `integrate-library-1.2.4`.
 
 Unfortunately, you discover after your merge that the library has a bug, which
-has to be fixed by this other team. To prevent from releasing it into production,
-you decide to revert the merge commit.
+has to be fixed by this other team. To prevent the bug from being released into
+production, you decide to revert the merge commit.
 
 ## The task
 * Revert the merge commit

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -3,6 +3,7 @@
 In this kata, we explore the problems of reverting a merge commit.
 
 ## The story
+
 Your team uses this amazing library-1.2.3 for its development, which is
 maintained by another team.
 
@@ -14,6 +15,7 @@ has to be fixed by this other team. To prevent the bug from being released into
 production, you decide to revert the merge commit.
 
 ## The task
+
 * Revert the merge commit  
   *Note: You may assume that feature Y is also working with the old library version*
 * Take the role of the library team and fix the bug in the library on the branch
@@ -21,6 +23,7 @@ production, you decide to revert the merge commit.
   Try to merge first to see what happens
 
 ## Useful commands
+
 * `git revert`
 * `git rebase`
 * `git merge`

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -1,3 +1,19 @@
 # Git Kata: Reverted merge
 
+In this kata, we explore the problems of reverting a merge commit.
+
+## The story
+Your team uses this amazing library-1.2.3 for its development, which is
+maintained by another team.
+
+At some point, your team integrates a new version library-1.2.4. Because you are
+prudent, you do this on a branch `integrate-library-1.2.4`.
+
+Unfortunately, you discover after your merge that the library has a bug, which
+has to be fixed by this other team. To prevent from releasing it into production,
+you revert the merge commit.
+
 ## The task
+* Take the role of the library team and fix the bug on the branch
+* Explore how you can get the changes from the branch into the master again  
+  Try to merge first to see what happens

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -e
+
+# Include utils
+source ../utils/utils.sh
+
+kata="reverted-merge"
+makerepo
+
+if [[ ! `pwd` =~ .*exercise.* ]]; then
+  echo "Not in correct directory"
+  echo "Exiting to prevent changes from surrounding repository"
+  return
+fi
+
+echo "library-1.2.3" > lib.txt
+echo "module using library-1.2.3" > mymodule.txt
+git add lib.txt mymodule.txt
+git commit -m"Adding module with its library"
+
+git branch integrate-library-1.2.4
+git checkout integrate-library-1.2.4
+
+echo "library-1.2.4" > lib.txt
+echo "module using library-1.2.4" > mymodule.txt
+git add lib.txt
+git add mymodule.txt
+git commit -m"Update to library version 1.2.4"
+
+echo "New libarry funtcionality" >> lib.txt
+git add lib.txt
+git commit -m"Add new library functionality"
+echo "Use new library functionality" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Use new functionality in mymodule"
+
+git checkout master
+echo "Add promising feature X" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Add feature X"
+
+git merge integrate-library-1.2.4 --no-edit
+# deal with merge conflict
+echo "module using library-1.2.4" > mymodule.txt
+echo "Add promising feature X" >> mymodule.txt
+echo "Use new library functionality" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Merge integrate-library-1.2.4" --no-edit
+
+echo "Add useful feature Y" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Add feature Y"
+
+git revert HEAD~1 -m 1 --no-edit
+echo "module using library-1.2.3" > mymodule.txt
+echo "Add promising feature X" >> mymodule.txt
+echo "Add useful feature Y" >> mymodule.txt
+git add mymodule.txt
+git commit --no-edit

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -44,12 +44,3 @@ git commit -m"Merge integrate-library-1.2.4" --no-edit
 echo "Useful feature Y" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Add feature Y"
-
-
-# git revert HEAD~1 -m 1 --no-edit
-# # deal with revert conflict
-# echo "module using library-1.2.3" > mymodule.txt
-# echo "Promising feature X" >> mymodule.txt
-# echo "Useful feature Y" >> mymodule.txt
-# git add mymodule.txt
-# git commit --no-edit

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -3,7 +3,6 @@
 # Include utils
 source ../utils/utils.sh
 
-kata="reverted-merge"
 makerepo
 
 echo "library-1.2.3" > lib.txt

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # Include utils
 source ../utils/utils.sh

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -6,12 +6,6 @@ source ../utils/utils.sh
 kata="reverted-merge"
 makerepo
 
-if [[ ! `pwd` =~ .*exercise.* ]]; then
-  echo "Not in correct directory"
-  echo "Exiting to prevent changes from surrounding repository"
-  return
-fi
-
 echo "library-1.2.3" > lib.txt
 echo "module using library-1.2.3" > mymodule.txt
 git add lib.txt mymodule.txt

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -21,38 +21,41 @@ git branch integrate-library-1.2.4
 git checkout integrate-library-1.2.4
 
 echo "library-1.2.4" > lib.txt
+echo "New libarry funtcionality" >> lib.txt
 echo "module using library-1.2.4" > mymodule.txt
 git add lib.txt
 git add mymodule.txt
 git commit -m"Update to library version 1.2.4"
 
-echo "New libarry funtcionality" >> lib.txt
-git add lib.txt
-git commit -m"Add new library functionality"
 echo "Use new library functionality" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Use new functionality in mymodule"
 
+
 git checkout master
-echo "Add promising feature X" >> mymodule.txt
+echo "Promising feature X" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Add feature X"
+
 
 git merge integrate-library-1.2.4 --no-edit
 # deal with merge conflict
 echo "module using library-1.2.4" > mymodule.txt
-echo "Add promising feature X" >> mymodule.txt
+echo "Promising feature X" >> mymodule.txt
 echo "Use new library functionality" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Merge integrate-library-1.2.4" --no-edit
 
-echo "Add useful feature Y" >> mymodule.txt
+
+echo "Useful feature Y" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Add feature Y"
 
-git revert HEAD~1 -m 1 --no-edit
-echo "module using library-1.2.3" > mymodule.txt
-echo "Add promising feature X" >> mymodule.txt
-echo "Add useful feature Y" >> mymodule.txt
-git add mymodule.txt
-git commit --no-edit
+
+# git revert HEAD~1 -m 1 --no-edit
+# # deal with revert conflict
+# echo "module using library-1.2.3" > mymodule.txt
+# echo "Promising feature X" >> mymodule.txt
+# echo "Useful feature Y" >> mymodule.txt
+# git add mymodule.txt
+# git commit --no-edit


### PR DESCRIPTION
I have added a kata to practise what happens when you revert a merge commit.

It can be used to explore the solutions proposed in:
https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt

I guess it is a quite advanced exercise and it follows only partly the style in the repository in that it focusses less on specific commands and more on a particular git situation.

However, I'd be glad to contribute it to your repository if you want.