### PR TITLE
Add second commit on wrong branch

### DIFF
--- a/commit-on-wrong-branch-2/README.md
+++ b/commit-on-wrong-branch-2/README.md
@@ -18,6 +18,6 @@ the `master` branch instead of the feature branch.
 
 ## Useful Commands
 
-* `git reset HEAD~1` to remove the last commit from the repository, i.e. move
-  the HEAD pointer to the commit before the last
+* `git reset HEAD~1` to move the current branch one step back. This has the consequence of _removing_ the newest commit from a branch
 * `git stash` to temporarily save your changes so that you can switch branches
+* `git cherry-pick` to add changeset from commit on current branch

--- a/commit-on-wrong-branch-2/README.md
+++ b/commit-on-wrong-branch-2/README.md
@@ -1,0 +1,19 @@
+# Git kata: Commit on wrong branch II
+
+## The Story
+You develop a new feature on the branch `new-feature`. You have already
+implemented the first part of a feature, when you are notified of a critical
+bug that has to be fixed right away on the `master` branch.
+
+After the bug fix, you continue to work on the new feature. After you committed
+the second part of the feature, you realize that you have done your commit on
+the `master` branch instead of the feature branch.
+
+## The task
+* Move the commit from the `master` branch to the `new-feature` branch.
+* What should happen to the bug fix with respect to the `new-feature` branch?
+
+## Useful Commands
+* `git reset HEAD~1` to remove the last commit from the repository, i.e. move
+  the HEAD pointer to the commit before the last
+* `git stash` to temporarily save your changes so that you can switch branches

--- a/commit-on-wrong-branch-2/setup.sh
+++ b/commit-on-wrong-branch-2/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Include utils
+source ../utils/utils.sh
+
+makerepo
+
+echo "Some coode" > myapp.txt
+git add myapp.txt
+git commit -m"Initial commit"
+
+git checkout -b new-feature
+echo "First part of new awesome feature" >> myapp.txt
+git add myapp.txt
+git commit -m"Implement first part of feature"
+
+git checkout master
+echo "Some code" > myapp.txt
+git add myapp.txt
+git commit -m"Fix bug"
+
+echo "Second part of new feature" >> myapp.txt
+git add myapp.txt
+git commit -m"Implement second part of feature"

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -1,0 +1,3 @@
+# Git Kata: Reverted merge
+
+## The task

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -11,9 +11,15 @@ prudent, you do this on a branch `integrate-library-1.2.4`.
 
 Unfortunately, you discover after your merge that the library has a bug, which
 has to be fixed by this other team. To prevent from releasing it into production,
-you revert the merge commit.
+you decide to revert the merge commit.
 
 ## The task
-* Take the role of the library team and fix the bug on the branch
+* Revert the merge commit
+* Take the role of the library team and fix the bug in the library on the branch
 * Explore how you can get the changes from the branch into the master again  
   Try to merge first to see what happens
+
+## Useful commands
+* `git revert`
+* `git rebase`
+* `git merge`

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -10,8 +10,8 @@ At some point, your team integrates a new version library-1.2.4. Because you are
 prudent, you do this on a branch `integrate-library-1.2.4`.
 
 Unfortunately, you discover after your merge that the library has a bug, which
-has to be fixed by this other team. To prevent from releasing it into production,
-you decide to revert the merge commit.
+has to be fixed by this other team. To prevent the bug from being released into
+production, you decide to revert the merge commit.
 
 ## The task
 * Revert the merge commit

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -1,3 +1,19 @@
 # Git Kata: Reverted merge
 
+In this kata, we explore the problems of reverting a merge commit.
+
+## The story
+Your team uses this amazing library-1.2.3 for its development, which is
+maintained by another team.
+
+At some point, your team integrates a new version library-1.2.4. Because you are
+prudent, you do this on a branch `integrate-library-1.2.4`.
+
+Unfortunately, you discover after your merge that the library has a bug, which
+has to be fixed by this other team. To prevent from releasing it into production,
+you revert the merge commit.
+
 ## The task
+* Take the role of the library team and fix the bug on the branch
+* Explore how you can get the changes from the branch into the master again  
+  Try to merge first to see what happens

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -e
+
+# Include utils
+source ../utils/utils.sh
+
+kata="reverted-merge"
+makerepo
+
+if [[ ! `pwd` =~ .*exercise.* ]]; then
+  echo "Not in correct directory"
+  echo "Exiting to prevent changes from surrounding repository"
+  return
+fi
+
+echo "library-1.2.3" > lib.txt
+echo "module using library-1.2.3" > mymodule.txt
+git add lib.txt mymodule.txt
+git commit -m"Adding module with its library"
+
+git branch integrate-library-1.2.4
+git checkout integrate-library-1.2.4
+
+echo "library-1.2.4" > lib.txt
+echo "module using library-1.2.4" > mymodule.txt
+git add lib.txt
+git add mymodule.txt
+git commit -m"Update to library version 1.2.4"
+
+echo "New libarry funtcionality" >> lib.txt
+git add lib.txt
+git commit -m"Add new library functionality"
+echo "Use new library functionality" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Use new functionality in mymodule"
+
+git checkout master
+echo "Add promising feature X" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Add feature X"
+
+git merge integrate-library-1.2.4 --no-edit
+# deal with merge conflict
+echo "module using library-1.2.4" > mymodule.txt
+echo "Add promising feature X" >> mymodule.txt
+echo "Use new library functionality" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Merge integrate-library-1.2.4" --no-edit
+
+echo "Add useful feature Y" >> mymodule.txt
+git add mymodule.txt
+git commit -m"Add feature Y"
+
+git revert HEAD~1 -m 1 --no-edit
+echo "module using library-1.2.3" > mymodule.txt
+echo "Add promising feature X" >> mymodule.txt
+echo "Add useful feature Y" >> mymodule.txt
+git add mymodule.txt
+git commit --no-edit

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -21,38 +21,41 @@ git branch integrate-library-1.2.4
 git checkout integrate-library-1.2.4
 
 echo "library-1.2.4" > lib.txt
+echo "New libarry funtcionality" >> lib.txt
 echo "module using library-1.2.4" > mymodule.txt
 git add lib.txt
 git add mymodule.txt
 git commit -m"Update to library version 1.2.4"
 
-echo "New libarry funtcionality" >> lib.txt
-git add lib.txt
-git commit -m"Add new library functionality"
 echo "Use new library functionality" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Use new functionality in mymodule"
 
+
 git checkout master
-echo "Add promising feature X" >> mymodule.txt
+echo "Promising feature X" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Add feature X"
+
 
 git merge integrate-library-1.2.4 --no-edit
 # deal with merge conflict
 echo "module using library-1.2.4" > mymodule.txt
-echo "Add promising feature X" >> mymodule.txt
+echo "Promising feature X" >> mymodule.txt
 echo "Use new library functionality" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Merge integrate-library-1.2.4" --no-edit
 
-echo "Add useful feature Y" >> mymodule.txt
+
+echo "Useful feature Y" >> mymodule.txt
 git add mymodule.txt
 git commit -m"Add feature Y"
 
-git revert HEAD~1 -m 1 --no-edit
-echo "module using library-1.2.3" > mymodule.txt
-echo "Add promising feature X" >> mymodule.txt
-echo "Add useful feature Y" >> mymodule.txt
-git add mymodule.txt
-git commit --no-edit
+
+# git revert HEAD~1 -m 1 --no-edit
+# # deal with revert conflict
+# echo "module using library-1.2.3" > mymodule.txt
+# echo "Promising feature X" >> mymodule.txt
+# echo "Useful feature Y" >> mymodule.txt
+# git add mymodule.txt
+# git commit --no-edit

--- a/submodules/README.md
+++ b/submodules/README.md
@@ -28,7 +28,7 @@ Go to the `product` repository.
 
 1. Does `git status` or `git submodule status` tell you anything about this new commit?
 1. Go to the `include` path and `git pull` the latest version.
-1. Go to the `project` path. What is the status now in your product repository?
+1. Go to the `product` path. What is the status now in your product repository?
 1. Go to your `include` folder. Make a change and `push` it back to its origin.
 
 Go to the `exercise` directory. We will make a clone.


### PR DESCRIPTION
In addition to the reverted-merge kata, I have also created a second kata that explores how you can move a commit that has accidentally landed on the wrong branch to the correct branch.

The existing kata has its value in that it shows how to deal with putting a commit in between two others by rebasing (at least that is a solution that I found). However I find that there is at least a second situation where you have accidentally committed on the wrong branch and where you cannot easily use rebasing, but can use stash and reset instead.

I'd value any comments that you have on this exercise and be glad if you'd accept my contribution.

Perhaps you also have a better name than putting a "2" at the end... 