### PR TITLE
Fix error in setup of basic-branching kata

### DIFF
--- a/basic-branching/setup.sh
+++ b/basic-branching/setup.sh
@@ -6,7 +6,6 @@ source ../utils/utils.sh
 kata="basic-branching"
 makerepo
 
-git checkout master
 echo "dummy" > dummy.txt
 git add dummy.txt
 git commit -m "dummy commit"


### PR DESCRIPTION
This commit will fix an error in the setup.sh of the
basic-branching kata.
After `git init` the setup script tried to checkout the already
checked out master branch. that showed an error:
`error: pathspec 'master' did not match any file(s) known to git`

Closes #117