### PR TITLE
Add PowerShell setup files for further katas

### DIFF
--- a/commit-on-wrong-branch-2/README.md
+++ b/commit-on-wrong-branch-2/README.md
@@ -12,7 +12,7 @@ the `master` branch instead of the feature branch.
 
 ## The task
 
-1. Run `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 2. Move the faulty commit from the `master` branch to the `new-feature` branch.
 3. How would you also bring the bugfix to your feature branch?
 

--- a/commit-on-wrong-branch-2/setup.ps1
+++ b/commit-on-wrong-branch-2/setup.ps1
@@ -1,0 +1,29 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "Some coode" -Path myapp.txt
+Add-Content -Value "Some other line of code" -Path myapp.txt
+Add-Content -Value "Another line of code" -Path myapp.txt
+
+git add myapp.txt
+git commit -m "Initial commit"
+
+git checkout -b new-feature
+
+Add-Content -Value "First part of new awesome feature" -Path myapp.txt
+
+git add myapp.txt
+git commit -m "Implement first part of feature"
+
+git checkout master
+
+Set-Content -Value "Some coode" -Path myapp.txt
+Add-Content -Value "Some other line of code" -Path myapp.txt
+Add-Content -Value "Another line of code" -Path myapp.txt
+
+git add myapp.txt
+git commit -m "Fix bug"
+
+Add-Content -Value "Second part of new feature" -Path myapp.txt
+
+git add myapp.txt
+git commit -m "Implement second part of feature"

--- a/detached-head/README.md
+++ b/detached-head/README.md
@@ -2,7 +2,7 @@
 ## detached head state
 
 To get the full experience from this exercise do:
-`. ./setup.sh`.
+`. setup.sh` (or `.\setup.ps1` in PowerShell)
 
 The user has ended up in a "detached head" state in the `kata3-detached-head-master` branch.
 

--- a/detached-head/setup.ps1
+++ b/detached-head/setup.ps1
@@ -1,0 +1,23 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "" -Path file1
+
+git add file1
+git commit -am "A"
+
+Set-Content -Value "" -Path file2
+
+git add file2
+git commit -am "B"
+
+Set-Content -Value "" -Path file3
+
+git add file3
+git commit -am "C"
+
+Set-Content -Value "" -Path file4
+
+git add file4
+git commit -am "D"
+
+git checkout HEAD~3

--- a/ff-merge/README.md
+++ b/ff-merge/README.md
@@ -3,7 +3,7 @@
 
 You again live in your own branch, this time we will be doing a bit of juggling with branches, to show how lightweight branches are in git.
 
-1. Run the command `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. Create a branch called uppercase
 1. Checkout the branch
 1. What is the output of `git status`?

--- a/ff-merge/setup.ps1
+++ b/ff-merge/setup.ps1
@@ -1,0 +1,11 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "" -Path greeting.txt
+
+git add greeting.txt
+git commit -m "Add file greeting.txt"
+
+Set-Content -Value "hello" -Path greeting.txt
+
+git add greeting.txt
+git commit -m "Add content to greeting.txt"

--- a/ignore/README.md
+++ b/ignore/README.md
@@ -9,7 +9,7 @@ If you want to signal to git that a file needs to be removed from git, but still
 
 ## The task
 
-1. Run the command `./setup.sh` and `cd exercise`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. Create a file with the name `foo.s`
 1. What is the output of `git status`?
 1. Create a `.gitignore` file in your working directory containing `*.s`

--- a/ignore/setup.ps1
+++ b/ignore/setup.ps1
@@ -1,0 +1,7 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "hello" -Path file1.txt
+
+echo "hello" > file1.txt
+git init
+git checkout -b master

--- a/ignore/setup.ps1
+++ b/ignore/setup.ps1
@@ -2,6 +2,5 @@
 
 Set-Content -Value "hello" -Path file1.txt
 
-echo "hello" > file1.txt
 git init
 git checkout -b master

--- a/investigation/README.md
+++ b/investigation/README.md
@@ -1,4 +1,5 @@
 # Git Kata: Git objects
+
 Objects are stored in `<repository>/.git/objects` in subfolders matching the first two chars of the sha.
 `fc1da6e8f` is therefore the file: `.git/objects/fc/1da6e8f`.
 
@@ -8,6 +9,8 @@ Objects are stored in `<repository>/.git/objects` in subfolders matching the fir
 `git ls-tree master .` inflates and lists the content of a folder.
 
 ## Task
-Using `git ls-tree` and `git cat-file`, draw the entire Git datastructure.
-- What tree and blob objects do you have and what do they point at
-- What commits point inside this graph and where?
+
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Using `git ls-tree` and `git cat-file`, draw the entire Git datastructure.
+	- What tree and blob objects do you have and what do they point at?
+	- What commits point inside this graph and where?

--- a/investigation/setup.ps1
+++ b/investigation/setup.ps1
@@ -1,0 +1,24 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "" -Path test.md
+
+git add test.md
+git commit -m "Add test.md"
+
+New-Item src -ItemType Directory | Out-Null
+New-Item src\main -ItemType Directory | Out-Null
+Set-Content -Value "" -Path "src\file.c"
+Set-Content -Value "" -Path "src\main\main.h"
+
+git add src/
+git commit -m "Add folders"
+
+Set-Content -Value "This is more data" -Path "src\main\main.h"
+
+git add src/main/main.h
+git commit -m "Put data in main.h"
+
+Set-Content -Value "This is also a bunch of data" -Path "test.md"
+
+git add test.md
+git commit -m "Fill test.md"

--- a/merge-conflict/README.md
+++ b/merge-conflict/README.md
@@ -1,6 +1,9 @@
 # Git Kata: Merge Conflict
+
 ## The task
-Run the command `. setup.sh` to the repository containing the exercise.
+
+Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+
 In this kata git cannot figure how to merge the content added on `merge-conflict-branch1` with the content on `master`.
 
 Both changes need to be in master when you're done.

--- a/merge-conflict/setup.ps1
+++ b/merge-conflict/setup.ps1
@@ -1,0 +1,26 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "" -Path greeting.txt
+
+git add greeting.txt
+git commit -m "Add file greeting.txt"
+
+Set-Content -Value "hello" -Path greeting.txt
+
+git add greeting.txt
+git commit -m "Add content to greeting.txt"
+
+# Create a file on branch1
+git checkout -b merge-conflict-branch1
+
+Set-Content -Value "This is a relevant fact" -Path file.txt
+
+git add file.txt
+git commit -m "add relevant fact"
+
+git checkout master
+
+Set-Content -Value "This is an indispensable truth!" -Path file.txt
+
+git add file.txt
+git commit -m "add indispensable truth!"

--- a/merge-mergesort/README.md
+++ b/merge-mergesort/README.md
@@ -9,7 +9,7 @@ The task is to look at the merge conflict, and solve it by editing the file acco
 
 ## The task
 
-1. Run the command `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. run `git branch` to see the two branches present
 1. `git merge Mergesort-impl`
 1. Solve the merge conflict :)

--- a/merge-mergesort/setup.ps1
+++ b/merge-mergesort/setup.ps1
@@ -1,0 +1,20 @@
+. ..\utils\make-exercise-repo.ps1
+
+Copy-Item "..\base.py" -Destination "mergesort.py"
+
+git add mergesort.py
+git commit -m "Fake it till you make it - Faking mergesort using python .sort() method"
+
+git checkout -b "Mergesort-Impl"
+
+Copy-Item "..\righty.py" -Destination "mergesort.py"
+
+git add mergesort.py
+git commit -m "Mergesort implemented on feature branch"
+
+git checkout master
+
+Copy-Item "..\lefty.py" -Destination "mergesort.py"
+
+git add mergesort.py
+git commit -m "Mergesort implemented on master"

--- a/rebase-branch/README.md
+++ b/rebase-branch/README.md
@@ -1,9 +1,6 @@
 # Git Kata: rebase branch
 ## Setup:
-In your terminal, run
-```
-$ ./setup.sh && cd exercise
-```
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 
 
 ## The task

--- a/rebase-branch/setup.ps1
+++ b/rebase-branch/setup.ps1
@@ -1,0 +1,26 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "" -Path greeting.txt
+
+git add greeting.txt
+git commit -m "Add file greeting.txt"
+
+Set-Content -Value "hello" -Path greeting.txt
+
+git add greeting.txt
+git commit -m "Add content to greeting.txt"
+
+# Go to uppercase on a branch
+git checkout -b uppercase
+
+Set-Content -Value "HELLO" -Path greeting.txt
+
+git commit -am "Change greeting to uppercase"
+
+# Move forward on master
+git checkout master
+
+Set-Content -Value "Greetings library" -Path README.md
+
+git add README.md
+git commit -m "Add readme"

--- a/reorder-the-history/README.md
+++ b/reorder-the-history/README.md
@@ -6,7 +6,7 @@ You should fix this such that our `git log` looks great!
 
 ## Task
 
-1. Run the command `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. Reorder the history such that it actually makes sense
 
 ### useful commands

--- a/reorder-the-history/setup.ps1
+++ b/reorder-the-history/setup.ps1
@@ -1,0 +1,51 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "initial" -Path foo.txt
+
+git add foo.txt
+git commit -m "foo.txt"
+
+Set-Content -Value "1" -Path file1
+
+git add file1
+git commit -m "file1"
+
+Set-Content -Value "9" -Path file9
+
+git add file9
+git commit -m "file9"
+
+Set-Content -Value "8" -Path file8
+
+git add file8
+git commit -m "file8"
+
+Set-Content -Value "3" -Path file3
+
+git add file3
+git commit -m "file3"
+
+Set-Content -Value "4" -Path file4
+
+git add file4
+git commit -m "file4"
+
+Set-Content -Value "5" -Path file5
+
+git add file5
+git commit -m "file5"
+
+Set-Content -Value "2" -Path file2
+
+git add file2
+git commit -m "file2"
+
+Set-Content -Value "6" -Path file6
+
+git add file6
+git commit -m "file6"
+
+Set-Content -Value "7" -Path file7
+
+git add file7
+git commit -m "file7"

--- a/reset/README.md
+++ b/reset/README.md
@@ -4,7 +4,7 @@ We can manipulate the History very much so. We should only ever tinker with our 
 We use reset to unstage change, but we can also do many more different things.
 
 ## Task
-1. Run the command `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. How does your working directory look like?
 1. What does your log look like?
 1. Try to run `git reset --soft HEAD~1`

--- a/reset/setup.ps1
+++ b/reset/setup.ps1
@@ -1,0 +1,8 @@
+. ..\utils\make-exercise-repo.ps1
+
+for ($i=1; $i -le 10; $i++) {
+	Set-Content -Value $i -Path "$i.txt"
+
+	git add .
+	git commit -m $i
+}

--- a/reverted-merge/setup.ps1
+++ b/reverted-merge/setup.ps1
@@ -1,0 +1,45 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "library-1.2.3" -Path lib.txt
+Set-Content -Value "module using library-1.2.3" -Path mymodule.txt
+
+git add lib.txt mymodule.txt
+git commit -m "Adding module with its library"
+
+git branch integrate-library-1.2.4
+git checkout integrate-library-1.2.4
+
+Set-Content -Value "library-1.2.4" -Path lib.txt
+Add-Content -Value "New library functionality" -Path lib.txt
+Set-Content -Value "module using library-1.2.4" -Path mymodule.txt
+
+git add lib.txt
+git add mymodule.txt
+git commit -m "Update to library version 1.2.4"
+
+Add-Content -Value "Use new library functionality" -Path mymodule.txt
+
+git add mymodule.txt
+git commit -m "Use new functionality in mymodule"
+
+git checkout master
+
+Add-Content -Value "Promising feature X" -Path mymodule.txt
+
+git add mymodule.txt
+git commit -m "Add feature X"
+
+git merge integrate-library-1.2.4 --no-edit
+
+# deal with merge conflict
+Set-Content -Value "module using library-1.2.4" -Path mymodule.txt
+Add-Content -Value "Promising feature X" -Path mymodule.txt
+Add-Content -Value "Use new library functionality" -Path mymodule.txt
+
+git add mymodule.txt
+git commit -m "Merge integrate-library-1.2.4" --no-edit
+
+Add-Content -Value "Useful feature Y" -Path mymodule.txt
+
+git add mymodule.txt
+git commit -m "Add feature Y"

--- a/save-my-commit/README.md
+++ b/save-my-commit/README.md
@@ -4,11 +4,11 @@ We've lost the holy grail!
 Save it!
 
 # Task
-1. Run `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. Save the most important commit that was lost
 1. What's the difference between saving using reset and using cherry-pick?
 1. Remove the `exercise` folder.
-1. Run `. setup.sh`
+1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
 1. Run `git gc`
 1. Can you still save the lost commit?
 1. For extra credit what if someone reset their branch, force pushed and you pulled? Can you restore the old state?

--- a/save-my-commit/setup.ps1
+++ b/save-my-commit/setup.ps1
@@ -1,0 +1,23 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "initial" -Path thing.txt
+
+git add thing.txt
+git commit -m "Inital commit"
+
+Set-Content -Value "This is a relevant fact" -Path file.txt
+
+git add file.txt
+git commit -m "Add relevant fact"
+
+Set-Content -Value "This is an indispensable truth!" -Path file.txt
+
+git add file.txt
+git commit -m "Add indispensable truth!"
+
+Set-Content -Value "42" -Path holygrail.txt
+
+git add holygrail.txt
+git commit -m "Found the holy grail"
+
+git reset --hard HEAD~3

--- a/squashing/setup.ps1
+++ b/squashing/setup.ps1
@@ -1,0 +1,27 @@
+. ..\utils\make-exercise-repo.ps1
+
+Set-Content -Value "" -Path alsoafile.txt
+
+git add alsoafile.txt
+git commit -m "Initial file"
+
+Set-Content -Value "This is a relevant fact\n" -Path file.txt
+
+git add file.txt
+git commit -m "Add relevant fact"
+
+Add-Content -Value "This is also relevant\n" -Path file.txt
+
+git commit -am "Add more relevancy"
+
+Add-Content -Value "Perhaps this is the most relevant\n" -Path file.txt
+
+git commit -am "Most relevant!"
+
+Add-Content -Value "This is the prime directive\n" -Path file.txt
+
+git commit -am "Add prime directive"
+
+Add-Content -Value "NEVER change public history" -Path file.txt
+
+git commit -am "Add the word!"

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -1,0 +1,21 @@
+. ..\utils\make-exercise-repo.ps1
+
+New-Item component -ItemType Directory | Out-Null
+Set-Location component
+Set-Content -Value "" -Path component.h
+
+git init
+git add component.h
+git commit -m "Touch component header."
+
+Set-Location .\..
+
+New-Item product -ItemType Directory | Out-Null
+Set-Location product
+Set-Content -Value "" -Path product.h
+
+git init
+git add product.h
+git commit -m "Touch product header."
+
+Set-Location .\..


### PR DESCRIPTION
With this commit PowerShell setup files are added for the
following katas (now only the tricky ones are missing):
- commit-on-wrong-branch-2
- detached-head
- ff-merge
- ignore
- investigation
- merge-conflict
- merge-mergesort
- rebase-branch
- reorder-the-history
- reset
- reverted-merge
- save-my-commit
- squashing
- submodules