### PR TITLE
Remove `--decorate` in basic exercises log examples

### DIFF
--- a/3-way-merge/README.md
+++ b/3-way-merge/README.md
@@ -16,7 +16,7 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 1. Try adding README.md file to staging area using patch mode (it wont work)
 1. What is the output of `git status`?
 1. Add the README.md file to staging area and make the commit
-1. What is the output of `git log --oneline --decorate --graph --all`?
+1. What is the output of `git log --oneline --graph --all`?
 1. Diff the branches
 1. Merge the greeting branch into master
 
@@ -33,4 +33,4 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 - `git commit -m`
 - `git merge <branchA> <branchB>`
 - `git diff <branchA> <branchB>`
-- `git log --oneline --decorate --graph --all`
+- `git log --oneline --graph --all`

--- a/basic-branching/README.md
+++ b/basic-branching/README.md
@@ -12,16 +12,16 @@ Hint: `git checkout` will make you switch from one branch to another.
 1. Use `git branch mybranch` to create a new branch called _mybranch_
 1. Use `git branch` again to see the new branch created.
 1. Use `git checkout mybranch` to switch to your new branch.
-1. How does the output from `git status` change when you switch between the _master_ and the new branch that you have created? 
+1. How does the output from `git status` change when you switch between the _master_ and the new branch that you have created?
 1. How does the workspace change when you change between the two branches?
 1. Make sure you are on your _mybranch_ branch before you continue.
 1. Create a file called `file1.txt` with your name.
 1. `Add` the file and `commit` with this change.
-1. Use `git log --oneline --decorate --graph` to see your branch pointing to the new commit.
+1. Use `git log --oneline --graph` to see your branch pointing to the new commit.
 1. Switch back to the branch called _master_.
-1. Use `git log --oneline --decorate --graph` and notice how the commit you made on the _mybranch_ branch is missing on the _master_ branch.
+1. Use `git log --oneline --graph` and notice how the commit you made on the _mybranch_ branch is missing on the _master_ branch.
 1. Make a new file called `file2.txt` and commit that file.
-1. Use `git log --oneline --decorate --graph --all` to see your branch pointing to the new commit, and that the two branches now have different commits on them.
+1. Use `git log --oneline --graph --all` to see your branch pointing to the new commit, and that the two branches now have different commits on them.
 1. Switch to your branch _mybranch_.
 1. What happened to your working directory? Can you see your `file2.txt`?
 1. Use `git diff mybranch master` to see the difference between the two branches.
@@ -29,7 +29,6 @@ Hint: `git checkout` will make you switch from one branch to another.
 ## Useful commands
 - `git checkout`
 - `git checkout -b`
-- `git log --oneline --decorate --graph`
+- `git log --oneline --graph`
 - `git branch`
 - `git diff`
-

--- a/basic-commits/README.md
+++ b/basic-commits/README.md
@@ -33,7 +33,7 @@ You can look at the bottom of this file, if you have not yet done basic git conf
 - `git log`
 - `git log -n 5`
 - `git log --oneline`
-- `git log --oneline --decorate --graph`
+- `git log --oneline --graph`
 - `touch filename` to create a file (or `sc filename ''` in PowerShell)
 - `echo content > file` to overwrite file with content (or `sc filename 'content'` in PowerShell)
 - `echo content >> file` to append file with content (or `ac filename 'content'` in PowerShell)

--- a/basic-revert/README.md
+++ b/basic-revert/README.md
@@ -10,7 +10,7 @@ You again live in your own branch, this time we will revert some change on a bra
 1. Create a branch called `reverting`
 1. Checkout the branch
 1. What is the output of `git branch`?
-1. What is the output of `git log --oneline --decorate --graph --all`
+1. What is the output of `git log --oneline --graph --all`
 1. Use `cat` to see the contents of the greetings
 1. Revert the latest change, so you get the original content in the file
 1. Use `cat` to see the contents of the greetings
@@ -27,4 +27,4 @@ You again live in your own branch, this time we will revert some change on a bra
 - `git commit -m`
 - `git revert <sha1>`
 - `git diff <branchA> <branchB>`
-- `git log --oneline --decorate --graph --all`
+- `git log --oneline --graph --all`

--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -22,7 +22,7 @@ You live in your own repository. There is a file called file.txt
 
 1. What's the content of file.txt?
 1. Overwrite the content in file.txt: `echo 2 > file.txt` to change the state of your file in the working directory (or `sc file.txt '2'` in PowerShell)
-1. What does `git diff` tell you? 
+1. What does `git diff` tell you?
 1. What does `git diff --staged` tell you? why is this blank?
 1. Run `git add file.txt` to stage your changes from the working directory.
 1. What does `git diff` tell you?
@@ -38,7 +38,7 @@ You live in your own repository. There is a file called file.txt
 1. What does the log look like?
 1. Overwrite the content in file.txt: `echo 4 > file.txt` (or `sc file.txt '4'` in PowerShell)
 1. What is the content of file.txt?
-1. What does `git status` tell us?    
+1. What does `git status` tell us?
 1. Run `git checkout file.txt`
 1. What is the content of file.txt?
 1. What does `git status` tell us?
@@ -51,11 +51,11 @@ You live in your own repository. There is a file called file.txt
 - `git commit`
 - `git commit -m`
 - `git reset`
-- `git checkout`        
+- `git checkout`
 - `git log`
 - `git log -n 5`
 - `git log --oneline`
-- `git log --oneline --decorate --graph`
+- `git log --oneline --graph`
 - `git reset HEAD `
 - `git checkout`
 

--- a/ff-merge/README.md
+++ b/ff-merge/README.md
@@ -13,7 +13,7 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 1. Edit the greeting.txt to contain an uppercase greeting
 1. Add greeting.txt files to staging area and commit
 1. What is the output of `git branch`?
-1. What is the output of `git log --oneline --decorate --graph --all`
+1. What is the output of `git log --oneline --graph --all`
 1. Checkout `master` branch
 1. Use `cat` to see the contents of the greetings
 1. Diff the branches
@@ -32,4 +32,4 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 - `git commit -m`
 - `git merge <branch>`
 - `git diff <branchA> <branchB>`
-- `git log --oneline --decorate --graph --all`
+- `git log --oneline --graph --all`


### PR DESCRIPTION
The default `--decorate` behavior is now default in git log
unless you specify e.g. `--decorate=full`

There is no reason to confuse beginners with something that is default
behavior anyway.