### PR TITLE
double [[ ]] fails in WSL bash.

### DIFF
--- a/bisect/verify.sh
+++ b/bisect/verify.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env sh
 
 cd exercise
-if [[ "$(git log -1 --format='%s' refs/bisect/bad -- )" = '22' ]] ; then
+if [ "$(git log -1 --format='%s' refs/bisect/bad -- )" = '22' ] ; then
   echo "You managed to find the bad commit with bisect"
 else
   echo "You have still stuff to do"


### PR DESCRIPTION
w.r.t. https://serverfault.com/questions/52034/what-is-the-difference-between-double-and-single-square-brackets-in-bash

"my" shell wouldn't work properly with the double square brackets. I got `./verify.sh: 4: ./verify.sh: [[: not found`.

I'm opening this as a PR so you can discuss what's up.