### PR TITLE
Remove usage of patch mode add from 3-way-merge exercise

### DIFF
--- a/3-way-merge/README.md
+++ b/3-way-merge/README.md
@@ -9,12 +9,10 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 
 1. Create a branch called greeting and check it out
 1. Edit the greeting.txt to contain your favorite greeting
-1. Add greeting.txt files to staging area using patch mode (`-p`)
+1. Add greeting.txt files to the staging area
 1. Commit
 1. Switch back to the master branch
 1. Create a file README.md with information about this repository
-1. Try adding README.md file to staging area using patch mode (it won't work)
-1. What is the output of `git status`?
 1. Add the README.md file to staging area and make the commit
 1. What is the output of `git log --oneline --graph --all`?
 1. Diff the branches
@@ -28,7 +26,6 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 - `git checkout -b <branch-name>`
 - `git branch -v`
 - `git add`
-- `git add -p`
 - `git commit`
 - `git commit -m`
 - `git merge <branchA> <branchB>`


### PR DESCRIPTION
As suggested in #170 patch mode add is an advanced topic that does not fit the level of this
exercise and the time and way it is typically used in training.