### PR TITLE
Remove --decorate from katas

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ git config --global alias.co "checkout"
 git co      # Does a "git checkout"
 
 ## Logging
-git log --graph --decorate --pretty=oneline --abbrev-commit --all # Show a nice graph of the previous commits
+git log --graph --pretty=oneline --abbrev-commit --all # Show a nice graph of the previous commits
 ## Adding an alias called "lol" (log oneline..) that shows the above
-git config --global alias.lol "log --graph --decorate --pretty=oneline --abbrev-commit --all"
+git config --global alias.lol "log --graph --pretty=oneline --abbrev-commit --all"
 ## Using the alias
-git lol     # Does a "git log --graph --decorate --pretty=oneline --abbrev-commit --all"
+git lol     # Does a "git log --graph --pretty=oneline --abbrev-commit --all"
 ```
 
 ## Testing

--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -62,5 +62,5 @@ You live in your own repository. There is a file called file.txt
 ## Aliases
 
 You can set up aliases as such:
-`git config --global alias.lol 'log --oneline --decorate --graph --all'`
+`git config --global alias.lol 'log --oneline --graph --all'`
 This might be useful to you.

--- a/basic-stashing/README.md
+++ b/basic-stashing/README.md
@@ -1,4 +1,4 @@
-# Git Kata: Basic stashing 
+# Git Kata: Basic stashing
 
 ## Setup:
 
@@ -10,28 +10,28 @@ You are working on your project. You've staged some work and have some unstaged 
 Suddenly, you're made aware that a bug has made it to production. You'll stash your work, fix the bug and get back to your original work.
 
 1. Explore the repo
-   1. What work do you have in the working directory? 
-   1. What work do you have staged ?  
-   1. What does the commit log look like ?  
-   >*Notice that file.txt has some staged changes (i.e. changes in the index) and unstaged changes (changes in the working directory)* 
+   1. What work do you have in the working directory?
+   1. What work do you have staged ?
+   1. What does the commit log look like ?
+   >*Notice that file.txt has some staged changes (i.e. changes in the index) and unstaged changes (changes in the working directory)*
 1. Use `git stash` to stash your current work.
-   1. Now, what work do you have in the working directory? 
+   1. Now, what work do you have in the working directory?
    1. What work do you have staged ?
    1. What does the commit log look like ?
    1. What does the stash list look like ?
 1. Fix the typos in bug.txt on master and commit your changes.
 1. Now to get back to your work, apply the stash to master.
-   1. What work do you have in the working directory? 
+   1. What work do you have in the working directory?
    1. What work do you have staged ?
    >*Oops. All our changes are unstaged now. This may be undesirable and unexpected*
 1. Undo our changes with `git reset --hard HEAD`. This is an unsafe command as it will remove files from your index and working directory permanently, but we have our changes safely stashed so we're ok. Review the [reset](reset/README.md) kata if you're unsure of what happens here.
 1. Apply the stash to master with the `--index` option.
-   1. What work do you have in the working directory? 
+   1. What work do you have in the working directory?
    1. What work do you have staged ?
    >*Ok, back to where we were!*
 1. We won't need the stash anymore. Drop it.
    1. What does the stash list look like ?
-   1. What does the commit log look like ?  
+   1. What does the commit log look like ?
 
 
 
@@ -46,6 +46,6 @@ Suddenly, you're made aware that a bug has made it to production. You'll stash y
 - `git stash apply`
 - `git stash apply --index`
 - `git stash drop`
-- `git log --oneline --decorate --all --graph`
+- `git log --oneline --all --graph`
 - `git commit`
 - `git add`

--- a/configure-git/README.md
+++ b/configure-git/README.md
@@ -19,7 +19,7 @@ or alternatively:
 ## Aliases
 
 You can set up aliases as such:
-* `git config --global alias.lol 'log --oneline --decorate --graph --all'`
+* `git config --global alias.lol 'log --oneline --graph --all'`
 
 This might be useful to you.
 

--- a/ignore/README.md
+++ b/ignore/README.md
@@ -38,5 +38,5 @@ If you want to signal to git that a file needs to be removed from git, but still
 
 ## Aliases
 You can set up aliases as such:
-`git config --global alias.lol 'log --oneline --decorate --graph --all'`
+`git config --global alias.lol 'log --oneline --graph --all'`
 This might be useful to you.

--- a/rebase-branch/README.md
+++ b/rebase-branch/README.md
@@ -20,5 +20,5 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 ## Useful commands
 - `git checkout <branch-name>`
 - `git rebase <branch-name>`
-- `git log --oneline --decorate --graph --all`
+- `git log --oneline --graph --all`
 - `git merge <branch-name>`


### PR DESCRIPTION
The --decorate option is default in git log, and provides no value in
the form where it is currently used in the examples.