### PR TITLE
Style: mark 'file.txt' as code

### DIFF
--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -18,16 +18,16 @@ We will also work with `git reset` to reset the staged changes of a file, and `g
 
 ## The task
 
-You live in your own repository. There is a file called file.txt
+You live in your own repository. There is a file called `file.txt`.
 
-1. What's the content of file.txt?
-1. Overwrite the content in file.txt: `echo 2 > file.txt` to change the state of your file in the working directory (or `sc file.txt '2'` in PowerShell)
+1. What's the content of `file.txt`?
+1. Overwrite the content in `file.txt`: `echo 2 > file.txt` to change the state of your file in the working directory (or `sc file.txt '2'` in PowerShell)
 1. What does `git diff` tell you?
 1. What does `git diff --staged` tell you? why is this blank?
 1. Run `git add file.txt` to stage your changes from the working directory.
 1. What does `git diff` tell you?
 1. What does `git diff --staged` tell you?
-1. Overwrite the content in file.txt: `echo 3 > file.txt` to change the state of your file in the working directory (or `sc file.txt '3'` in PowerShell).
+1. Overwrite the content in `file.txt`: `echo 3 > file.txt` to change the state of your file in the working directory (or `sc file.txt '3'` in PowerShell).
 1. What does `git diff` tell you?
 1. What does `git diff --staged` tell you?
 1. Explain what is happening
@@ -36,11 +36,11 @@ You live in your own repository. There is a file called file.txt
 1. What does git status tell you now?
 1. Stage the change and make a commit
 1. What does the log look like?
-1. Overwrite the content in file.txt: `echo 4 > file.txt` (or `sc file.txt '4'` in PowerShell)
-1. What is the content of file.txt?
+1. Overwrite the content in `file.txt`: `echo 4 > file.txt` (or `sc file.txt '4'` in PowerShell)
+1. What is the content of `file.txt`?
 1. What does `git status` tell us?
 1. Run `git checkout file.txt`
-1. What is the content of file.txt?
+1. What is the content of `file.txt`?
 1. What does `git status` tell us?
 
 


### PR DESCRIPTION
Style unification: mark `file.txt` as code, since it is a command-line entity, not an English word.