### PR TITLE
Improve rebase exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.swp
 **/exercise
+**/remote

--- a/reorder-the-history/setup.sh
+++ b/reorder-the-history/setup.sh
@@ -3,15 +3,14 @@
 source ../utils/utils.sh
 
 makefakeremoterepo 
+clone_remote_to_exercise
 
 echo "initial" > foo.txt
 git add foo.txt
-git commit -m "foo.txt"
-
-cd ..
-rm -rf exercise/
-git clone remote exercise
-cd exercise
+git commit -m "Initial commit"
+git tag -m 'Start' START
+git push origin master
+git push origin START
 
 echo "1" > file1
 git add file1

--- a/reorder-the-history/setup.sh
+++ b/reorder-the-history/setup.sh
@@ -2,11 +2,16 @@
 #Include utils
 source ../utils/utils.sh
 
-makerepo 
+makefakeremoterepo 
 
 echo "initial" > foo.txt
 git add foo.txt
 git commit -m "foo.txt"
+
+cd ..
+rm -rf exercise/
+git clone remote exercise
+cd exercise
 
 echo "1" > file1
 git add file1

--- a/utils/clone-remote-to-exercise.sh
+++ b/utils/clone-remote-to-exercise.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+clone_remote_to_exercise() {
+    rm -rf exercise/
+
+    # Clone remote
+    git clone ./remote exercise
+
+    # Go there
+    cd exercise
+}

--- a/utils/make-exercise-repo.sh
+++ b/utils/make-exercise-repo.sh
@@ -11,3 +11,16 @@ makerepo() {
     cd exercise
 
 }
+
+makefakeremoterepo() {
+
+    # First cleanup if there is an old exercise repository
+    rm -rf remote/
+
+    # Initialize a new repository
+    git init remote
+
+    # Go there
+    cd remote
+
+}

--- a/utils/make-exercise-repo.sh
+++ b/utils/make-exercise-repo.sh
@@ -11,16 +11,3 @@ makerepo() {
     cd exercise
 
 }
-
-makefakeremoterepo() {
-
-    # First cleanup if there is an old exercise repository
-    rm -rf remote/
-
-    # Initialize a new repository
-    git init remote
-
-    # Go there
-    cd remote
-
-}

--- a/utils/make-fake-remote.sh
+++ b/utils/make-fake-remote.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+makefakeremoterepo() {
+    # First cleanup if there is an old exercise repository
+    rm -rf remote/
+
+    # Initialize a new remote repository
+    git init --bare remote
+}

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -6,3 +6,5 @@
 # Using this weird seemingly arbitrary path to avoid path issues. 
 # Please let me know the _right_ way to do this
 source ../utils/make-exercise-repo.sh
+source ../utils/make-fake-remote.sh
+source ../utils/clone-remote-to-exercise.sh


### PR DESCRIPTION
I was a bit tired of explaining that `git rebase -i` default behaviour didn't work in the exercise because there is no `origin/master` to go back to, so I fixed it. I figured there are other exercises that will need support for "remotes" so I made the improvement generalised by adding to the utils scripts.

This PR only contains the Shell scripts and changes to the reorder-the-history exercise. 
I have made similar additions to the Powershell scripts, but it seems they are still buggy (as testen in a Docker container on my mac), so I left them out of this PR.