### PR TITLE
Expand  on  submodules kata

### DIFF
--- a/submodules/README.md
+++ b/submodules/README.md
@@ -13,47 +13,51 @@ This allows you to grab source change directly, as well as _pushing_ them back.
 
 After running `. setup.sh` or `. ./setup.sh`, you'll be left with two repositories inside the `exercises` folder.
 
-* A `product` repository
-* A `component` repository.
+* A `product` repository.
+* A `component` repository cloned from `remote/component-repo.git`.
+* A `remote` directory conatining a `component-repo.git` repository. This is the "remote" repository that would exist on your preferred git repository host, e.g. github.com.
 
 Go to the `product` repository.
 
-1. Add component as a submodule of product by running `git submodule add ../component/ include`.
+1. Add component as a submodule of product by running `git submodule add ../remote/component-repo.git/ include`.
 2. What does your working directory look like?
 3. Does `git status` look like you expect?
 4. What if you cd to `include`?
-5. Commit the changes on the `product` repository.
+5. Run `git diff --cached` in `product`. Where can you find the commit id shown in the `+Subproject commit ...` line?
+6. Commit the changes on the `product` repository.
 
 Go to the `component` repository.
 
-6. Does it know that it is a submodule?
-7. Make a change.
-8. Commit it on the `component` repository.
-9. Execute `git checkout master~0` to detach the HEAD.  This workaround is required in order to push to this repository from the `component` submodule that was checkout in `product` repository.
+7. Does it know that it is used as a submodule?
+8. Make a change to the `component` repository and `git commit` and `git push` it.
 
 Go to the `product` repository.
 
-10. Does `git status` or `git submodule foreach 'git status'` tell you anything about this new commit?
-11. Go to the `include` path and `git pull` the latest version.
-12. Go to the `product` path. What is the status now in your product repository?
+9. Does `git status` or `git submodule foreach 'git status'` tell you anything about this new commit?
+10. Go to the `include` directory and `git pull` the latest version.
+11. Verify that the change from the `component` repository is available in `include`.
+12. Go to the `product` directory. What is the status now in your product repository? Also examine with `git diff`.
 13. Go to your `include` folder. Make a change and `push` it back to its origin.
 
 Go to the `exercise` directory. We will make a clone of product to illustrate how submodules in a clone must be initialized.
 
 14. Run `git clone product product_alpha`.
-15. What happened?
-16. Go to `product_alpha` directory, how does your working directory look, what does the log say, what is in the `include` directory?
-17. Use `git submodule init`, what does your include dir look like?
-18. Use `git submodule update`, what does your include dir look like now?
+15. Go to `product_alpha` directory, how does your working directory look, what does the log say and what is in the `include` directory?
+16. Run `git submodule init`, what does your `include` dir look like?
+17. Run `git submodule update`, what does your `include` dir look like now?
+18. Is the latest change from `component` available in include?
 
 Go to the `product` repository.
 
 19. Commit the changes on the `product` repository.
 
-Go to the `exercise` directory. We will make a second clone to illustrate TBD.
+Go to the `product_alpha` repository. We'll ensure that we have the latest changes from product.
 
-20. Run `git clone product product_beta`.
-21. What happened?
-22. Go to `product_beta` directory, how does your working directory look, what does the log say?
+20. Run `git submodule update`.
+19. Is the latest change from `component` available in include?
+20. Examine the output of `git submodule status`. Compare the commit id with the `component` repository.
+21. Run `git submodule update --remote`.
+19. Is the latest change from `component` available in include?
+20. Examine the output of `git submodule status`. Compare the commit id with the `component` repository.
 
 Draw this entire exercise!

--- a/submodules/README.md
+++ b/submodules/README.md
@@ -1,7 +1,7 @@
 # Git Katas: Submodules
 
 Submodules are a way to embed other git repositories into your own, retaining a pointer to its `origin`.
-This allows you to grab source change directly, as well as _pushing_ them back.
+This allows you to grab source changes directly, as well as _pushing_ them back.
 
 ## Setup
 
@@ -11,7 +11,7 @@ This allows you to grab source change directly, as well as _pushing_ them back.
 
 ## The task
 
-After running `. setup.sh` or `./setup.sh`, you'll be left with two repositories inside the `exercises` folder.
+After running the setup script, you'll be left with three repositories inside the `exercises` folder.
 
 * A `product` repository.
 * A `component` repository cloned from `remote/component-repo.git`.

--- a/submodules/README.md
+++ b/submodules/README.md
@@ -11,11 +11,11 @@ This allows you to grab source change directly, as well as _pushing_ them back.
 
 ## The task
 
-After running `. setup.sh` or `. ./setup.sh`, you'll be left with two repositories inside the `exercises` folder.
+After running `. setup.sh` or `./setup.sh`, you'll be left with two repositories inside the `exercises` folder.
 
 * A `product` repository.
 * A `component` repository cloned from `remote/component-repo.git`.
-* A `remote` directory conatining a `component-repo.git` repository. This is the "remote" repository that would exist on your preferred git repository host, e.g. github.com.
+* A `remote` directory containing a `component-repo.git` repository. This is the "remote" repository that would exist on your preferred Git repository host, e.g. github.com.
 
 Go to the `product` repository.
 

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -1,21 +1,36 @@
-. ..\utils\make-exercise-repo.ps1
+# First cleanup if there is an old exercise repository
+if (Test-Path .\exercise) {
+	Remove-Item .\exercise\ -force -recurse
+}
 
-New-Item component -ItemType Directory | Out-Null
-Set-Location component
+New-Item -ItemType Directory -Path exercise | Out-Null
+Set-Location .\exercise\
+
+# Create component repo
+New-Item -ItemType Directory -Path .\remote\component | Out-Null
+Set-Location .\remote\component
+git init
+
 Set-Content -Value "" -Path component.h
-
-git init
 git add component.h
-git commit -m "Touch component header."
+git commit -m "Touch component header"
 
-Set-Location .\..
+# Convert to a bare repository and delete the original working directory.
+Move-Item -Path ".git" -Destination ..\component-repo.git
+Set-Location ..\component-repo.git
+git config --bool core.bare true
+Set-Location ..
+Remove-Item -Path ./component -Force -Recurse
+Set-Location ..
 
-New-Item product -ItemType Directory | Out-Null
-Set-Location product
-Set-Content -Value "" -Path product.h
+# And clone it so that it is ready for the exrcise.
+git clone remote/component-repo.git component
 
-git init
-git add product.h
-git commit -m "Touch product header."
+# Create a product repository.
+git init product
+Set-Location -Path .\product
+Set-Content -Value "" -Path .\product.h
+git add .\product.h
+git commit -m "Touch product header"
 
 Set-Location .\..

--- a/submodules/setup.sh
+++ b/submodules/setup.sh
@@ -13,16 +13,27 @@ mkdir ${EXERCISE_DIR}
 
 cd ${EXERCISE_DIR}
 
-mkdir component
+# Create component repo
+mkdir -p remote/component
+git init remote/component
+cd remote/component
 
-cd component
-git init
 touch component.h
 git add component.h
-git commit -m "Touch component header."
+git commit -m "Touch component header"
 
+# Convert to a bare repository and delete the original working directory.
+mv .git ../component-repo.git
+cd ../component-repo.git
+git config --bool core.bare true
+cd ..
+rm -rf component/
 cd ..
 
+# And clone it so that it is ready for the exrcise.
+git clone remote/component-repo.git component
+
+# Create a product repository.
 mkdir product
 cd product
 git init


### PR DESCRIPTION
I've worked around the "git checkout master~0" hack by having a separate "remote" component-repo.git. This should make the exercise a little simpler at the cost of a more complex setup.

I also removed the second clone of the product, opting to instead update the product_alpha clone.

The rest is minor brush-ups and fixing numbering.