### PR TITLE
Add missing shebang in squashing/setup.sh

### DIFF
--- a/squashing/setup.sh
+++ b/squashing/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 kata="kata2-squashing"
 
 # Include utils


### PR DESCRIPTION
`setup.sh` should be executable according to the instructions given in README.md