### PR TITLE
changed how shell script could be sourced in katas

### DIFF
--- a/3-way-merge/README.md
+++ b/3-way-merge/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 You again live in your own branch, this time we will be doing a bit of juggling with branches, to show how lightweight branches are in git.

--- a/advanced-rebase-interactive/README.md
+++ b/advanced-rebase-interactive/README.md
@@ -14,7 +14,7 @@ As this is an advanced exercise, there are no specific steps to follow and no si
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## Task
 

--- a/amend/README.md
+++ b/amend/README.md
@@ -6,7 +6,7 @@ Sometimes we just forget something obvious that we want to fix quickly.
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/bad-commit/README.md
+++ b/bad-commit/README.md
@@ -7,7 +7,7 @@ Find the commit and revert it using bisect.
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/basic-branching/README.md
+++ b/basic-branching/README.md
@@ -1,7 +1,7 @@
 # Git Kata: Basic Branching
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 You again live in your own branch, this time we will be doing a bit of juggling with branches, to show how lightweight branches are in git.

--- a/basic-cleaning/README.md
+++ b/basic-cleaning/README.md
@@ -2,7 +2,7 @@
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 You are working on a project that involves generated files.  Say you are compiling C files into object files. Before checking out a new branch you want to start clean

--- a/basic-commits/README.md
+++ b/basic-commits/README.md
@@ -7,7 +7,7 @@ You can look at the bottom of this file, if you have not yet done basic git conf
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/basic-revert/README.md
+++ b/basic-revert/README.md
@@ -1,7 +1,7 @@
 # Git Kata: Basic revert
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -14,7 +14,7 @@ We will also work with `git reset` to reset the staged changes of a file, and `g
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/basic-stashing/README.md
+++ b/basic-stashing/README.md
@@ -2,7 +2,7 @@
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/bisect/README.md
+++ b/bisect/README.md
@@ -16,7 +16,7 @@ $ ./test.sh
 ```
 ## Setup:
 
-1. Run `. setup.sh`
+1. Run `source setup.sh`
 
 ## Tasks
 

--- a/commit-on-wrong-branch-2/README.md
+++ b/commit-on-wrong-branch-2/README.md
@@ -12,7 +12,7 @@ the `master` branch instead of the feature branch.
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/commit-on-wrong-branch/README.md
+++ b/commit-on-wrong-branch/README.md
@@ -1,7 +1,7 @@
 # gitkatas
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## Kata 5: Commit on wrong branch
 This kata was shameless ripped off from [Git Katas](http://blog.schauderhaft.de/gitkata/)

--- a/detached-head/README.md
+++ b/detached-head/README.md
@@ -4,7 +4,7 @@ When a user ends up in a "detached head" state, this is a scary situation, but a
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/ff-merge/README.md
+++ b/ff-merge/README.md
@@ -1,7 +1,7 @@
 # Git Kata: Fast-forward Merge
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/git-attributes/README.md
+++ b/git-attributes/README.md
@@ -9,7 +9,7 @@ are for GNU/Linux platforms and Mac.
 
 ## Setup:
 
-1. Run `. setup.sh`
+1. Run `source setup.sh`
 
 ## The task
 

--- a/git-tag/README.md
+++ b/git-tag/README.md
@@ -1,7 +1,7 @@
 # Git Kata: Tagging of the commits
 ## Setup:
 
-1. Run `. setup.sh`
+1. Run `source setup.sh`
 
 ## Motivation
 

--- a/ignore/README.md
+++ b/ignore/README.md
@@ -10,7 +10,7 @@ If you want to signal to git that a file needs to be removed from git, but still
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/investigation/README.md
+++ b/investigation/README.md
@@ -10,7 +10,7 @@ Objects are stored in `<repository>/.git/objects` in subfolders matching the fir
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## Task
 

--- a/merge-conflict/README.md
+++ b/merge-conflict/README.md
@@ -2,7 +2,7 @@
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/merge-driver/README.md
+++ b/merge-driver/README.md
@@ -7,7 +7,7 @@ We'll do this by setting up `merge-tst-files.sh` as a _merge driver_ for `.tst` 
 
 ## Setup:
 
-1. Run `. setup.sh`
+1. Run `source setup.sh`
 
 ## The task
 

--- a/merge-mergesort/README.md
+++ b/merge-mergesort/README.md
@@ -9,7 +9,7 @@ The task is to look at the merge conflict, and solve it by editing the file acco
 
 ## Setup:
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/rebase-branch/README.md
+++ b/rebase-branch/README.md
@@ -1,7 +1,7 @@
 # Git Kata: rebase branch
 
 ## Setup:
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 
 ## The task

--- a/rebase-exec/README.md
+++ b/rebase-exec/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## Task
 

--- a/reorder-the-history/README.md
+++ b/reorder-the-history/README.md
@@ -6,7 +6,7 @@ You should fix this such that our `git log` looks great!
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## Task
 

--- a/reset/README.md
+++ b/reset/README.md
@@ -5,7 +5,7 @@ We use reset to unstage change, but we can also do many more different things.
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## Task
 

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -16,7 +16,7 @@ production, you decide to revert the merge commit.
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/save-my-commit/README.md
+++ b/save-my-commit/README.md
@@ -4,7 +4,7 @@ Save it!
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 We just reset our commits. Try different ways to restore them.

--- a/squashing/README.md
+++ b/squashing/README.md
@@ -10,7 +10,7 @@ While you are at it I would really like the ugly `\n` characters inside `file.tx
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 ## The task
 

--- a/submodules/README.md
+++ b/submodules/README.md
@@ -5,7 +5,7 @@ This allows you to grab source changes directly, as well as _pushing_ them back.
 
 ## Setup
 
-1. Run `. setup.sh` (or `.\setup.ps1` in PowerShell)
+1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 > NOTE: If running setup.sh on windows, you can run into problems by sourcing the setup script. Instead, run `./setup.sh`, and the folders would be created correctly.
 


### PR DESCRIPTION
All README.md files from the suggested list* have been updated to use `source` command instead of `.`.

* https://github.com/praqma-training/git-katas/blob/master/Overview.md