### PR TITLE
use local remote for prepush kata

### DIFF
--- a/pre-push/README.md
+++ b/pre-push/README.md
@@ -1,12 +1,19 @@
 # Git kata: Git hooks
-Git hooks allows us to add functionality to git by intersecting in the control of git.
-In this case we want to stop our silly users from pushing to the master branch.
+
+Git hooks allows us to add functionality to Git by injected scripts in the control flow of Git.
+
+In this case, we want to stop users from pushing to the `master` branch.
+
 You can look in the `.git/hooks/` folder to see what hooks are available.
+
 They are all named `*.sample` to prevent them from being executed.
+## Setup
+
+- run `source setup.sh`
 
 ## Task
-1. Clone a repository ( or use one that you already have )
-2. In the repository's `.git/hooks/` folder put the file `pre-push` that's in this repository
-3. What happens when you try to push to master?
-4. What happens if you try to push to a different branch?
-5. What happens if you switch the if / else blocks?
+
+1. Put the `pre-push` hook into the hooks folder with the command `cp pre-push ./.git/hooks/pre-push`
+2. What happens when you try to push to `master`?
+3. What happens if you try to push to a different branch on the remote?
+4. What happens if you switch the if / else blocks in `./.git/hooks/pre-push`?

--- a/pre-push/setup.sh
+++ b/pre-push/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#Include utils
+source ../utils/utils.sh
+
+makefakeremoterepo 
+clone_remote_to_exercise
+
+touch README.md
+git add README.md
+git commit -m "Initial Commit"
+git push -u origin master
+cp ../pre-push pre-push


### PR DESCRIPTION
@MadsBaggesen addresses that the prepush kata is not self-contained in #165. This pull request uses a local remote instead.