### PR TITLE
Fix #248 - Consistently use dashes in utils function names

### DIFF
--- a/3-way-merge/setup.sh
+++ b/3-way-merge/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="3-way-merge"
-makerepo
+make-exercise-repo
 
 touch greeting.txt
 git add greeting.txt

--- a/advanced-rebase-interactive/setup.sh
+++ b/advanced-rebase-interactive/setup.sh
@@ -2,7 +2,7 @@
 #Include utils
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 git commit --allow-empty -m "Initial commit"
 

--- a/amend/setup.sh
+++ b/amend/setup.sh
@@ -4,7 +4,7 @@
 
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 echo "foo" > foo.txt
 
 echo "bar" > bar.txt

--- a/bad-commit/setup.sh
+++ b/bad-commit/setup.sh
@@ -5,7 +5,7 @@ source ../utils/utils.sh
 
 kata="kata4-bad-commit"
 
-makerepo
+make-exercise-repo
 
 touch file1
 git add file1

--- a/basic-cleaning/setup.sh
+++ b/basic-cleaning/setup.sh
@@ -5,7 +5,7 @@ source ../utils/utils.sh
 
 kata="basic-cleaning"
 
-makerepo 
+make-exercise-repo 
 mkdir src
 
 echo "** SOME USEFUL INFO ** " > README.txt

--- a/basic-commits/setup.sh
+++ b/basic-commits/setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 kata="basic-commits-master"
 source ../utils/utils.sh
-makerepo
+make-exercise-repo

--- a/bisect/setup.sh
+++ b/bisect/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 echo '#! /usr/bin/env bash' > 'test.sh'
 echo 'if [[ $(( $(find * | wc -l) + 10 )) -gt 32 ]] ;then' >> 'test.sh'

--- a/commit-on-wrong-branch-2/setup.sh
+++ b/commit-on-wrong-branch-2/setup.sh
@@ -3,7 +3,7 @@
 # Include utils
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 echo "Some coode" > myapp.txt
 echo "Some other line of code" >> myapp.txt

--- a/commit-on-wrong-branch/setup.sh
+++ b/commit-on-wrong-branch/setup.sh
@@ -5,7 +5,7 @@ source ../utils/utils.sh
 
 kata="kata5-commit-on-wrong-branch"
 
-makerepo 
+make-exercise-repo 
 
 touch file.txt
 

--- a/detached-head/setup.sh
+++ b/detached-head/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="kata3-detached-head"
-makerepo
+make-exercise-repo
 
 
 touch file1

--- a/ff-merge/setup.sh
+++ b/ff-merge/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="ff-merge"
-makerepo
+make-exercise-repo
 
 touch greeting.txt
 git add greeting.txt

--- a/git-attributes/setup.sh
+++ b/git-attributes/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="git-attributes"
-makerepo
+make-exercise-repo
 
 printf 'hello æøå\r\n' > file1.txt
 git init

--- a/git-tag/setup.sh
+++ b/git-tag/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="$(basename $(pwd))"
-makerepo
+make-exercise-repo
 
 echo "dummy" > dummy.txt
 git add dummy.txt

--- a/ignore/setup.sh
+++ b/ignore/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="basic-ignore"
-makerepo
+make-exercise-repo
 
 echo "hello" > file1.txt
 git init

--- a/investigation/setup.sh
+++ b/investigation/setup.sh
@@ -2,7 +2,7 @@
 
 # Include utils
 source ../utils/utils.sh
-makerepo
+make-exercise-repo
 
 touch test.md
 git add test.md

--- a/merge-conflict/setup.sh
+++ b/merge-conflict/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="merge-conflict"
-makerepo
+make-exercise-repo
 
 touch greeting.txt
 git add greeting.txt

--- a/merge-driver/setup.sh
+++ b/merge-driver/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="merge-driver"
-makerepo
+make-exercise-repo
 
 cp ../../utils/resources/merge-tst-files.sh merge-tst-files.sh
 git add merge-tst-files.sh

--- a/merge-mergesort/setup.sh
+++ b/merge-mergesort/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 
 kata="merge-mergesort"
-makerepo
+make-exercise-repo
 
 cp ../base.py mergesort.py
 git add mergesort.py

--- a/pre-push/setup.sh
+++ b/pre-push/setup.sh
@@ -2,8 +2,8 @@
 #Include utils
 source ../utils/utils.sh
 
-makefakeremoterepo 
-clone_remote_to_exercise
+make-bare-remote-repo 
+clone-remote-to-exercise
 
 touch README.md
 git add README.md

--- a/rebase-branch/setup.sh
+++ b/rebase-branch/setup.sh
@@ -4,7 +4,7 @@
 source ../utils/utils.sh
 kata="rebase-branch"
 
-makerepo
+make-exercise-repo
 
 touch greeting.txt
 git add greeting.txt

--- a/rebase-exec/setup.sh
+++ b/rebase-exec/setup.sh
@@ -2,7 +2,7 @@
 
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 echo "#! /usr/bin/env bash" > 'test.sh'
 echo 'echo "Running tests on commit $(git rev-parse --short HEAD)"' >> 'test.sh'

--- a/rebase-interactive-autosquash/setup.sh
+++ b/rebase-interactive-autosquash/setup.sh
@@ -2,7 +2,7 @@
 
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 git commit --allow-empty -m "Initial commit"
 

--- a/reorder-the-history/setup.sh
+++ b/reorder-the-history/setup.sh
@@ -2,8 +2,8 @@
 #Include utils
 source ../utils/utils.sh
 
-makefakeremoterepo 
-clone_remote_to_exercise
+make-bare-remote-repo 
+clone-remote-to-exercise
 
 echo "initial" > foo.txt
 git add foo.txt

--- a/reset/setup.sh
+++ b/reset/setup.sh
@@ -3,7 +3,7 @@
 # Include utils
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 for i in {1..10}
 do

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -3,7 +3,7 @@
 # Include utils
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 echo "library-1.2.3" > lib.txt
 echo "module using library-1.2.3" > mymodule.txt

--- a/save-my-commit/setup.sh
+++ b/save-my-commit/setup.sh
@@ -3,7 +3,7 @@ kata="kata6-save-my-commit"
 # Include utils
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 echo "initial" > thing.txt
 git add thing.txt

--- a/squashing/setup.sh
+++ b/squashing/setup.sh
@@ -4,7 +4,7 @@ kata="kata2-squashing"
 # Include utils
 source ../utils/utils.sh
 
-makerepo
+make-exercise-repo
 
 touch alsoafile.txt
 

--- a/utils/clone-remote-to-exercise.sh
+++ b/utils/clone-remote-to-exercise.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-clone_remote_to_exercise() {
+clone-remote-to-exercise() {
     rm -rf exercise/
 
     # Clone remote

--- a/utils/make-exercise-repo.sh
+++ b/utils/make-exercise-repo.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-makerepo() {
+make-exercise-repo() {
 
     # First cleanup if there is an old exercise repository
     rm -rf exercise/

--- a/utils/make-fake-remote.sh
+++ b/utils/make-fake-remote.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-makefakeremoterepo() {
+make-bare-remote-repo() {
     # First cleanup if there is an old exercise repository
     rm -rf remote/
 

--- a/utils/make-setup.sh
+++ b/utils/make-setup.sh
@@ -42,7 +42,7 @@ clear-local-user() {
 
 pre-setup () {
     kata="$(basename $(pwd))"   # kata: name of the exercise which is respective folder name
-    makerepo
+    make-exercise-repo
     config-local-username
 }
 


### PR DESCRIPTION
I changed all the function names to use dashes for word delimination.
I also renamed "makefakeremoterepository" to "make-bare-remote-repository".