### PR TITLE
Add fake author in master-based-workflow exercise

### DIFF
--- a/master-based-workflow/fitzgerald-pushes-before-we-do.sh
+++ b/master-based-workflow/fitzgerald-pushes-before-we-do.sh
@@ -4,5 +4,5 @@ cd ../fake-remote-repository
 git checkout master
 touch fitz-was-here.md
 git add fitz-was-here.md
-git commit -m "Fitz made this"
+git commit -m "Fitz made this" --autor "R. Fitzgerald <rfitz@example.com>"
 git checkout HEAD~0


### PR DESCRIPTION
To easily distinguish own commits from the "virtual" collaborator's
ones.