### PR TITLE
Fix setup scripts of `submodule` kata

### DIFF
--- a/submodules/README.md
+++ b/submodules/README.md
@@ -11,15 +11,15 @@ This allows you to grab source changes directly, as well as _pushing_ them back.
 
 ## The task
 
-After running the setup script, you'll be left with three repositories inside the `exercises` folder.
+After running the setup script, you'll be left with three repositories inside the `exercise` folder.
 
+* A `component` repository cloned from `remote`.
 * A `product` repository.
-* A `component` repository cloned from `remote/component-repo.git`.
-* A `remote` directory containing a `component-repo.git` repository. This is the "remote" repository that would exist on your preferred Git repository host, e.g. github.com.
+* A `remote` repository. This is the "remote" repository that would exist on your preferred Git repository host, e.g. github.com.
 
 Go to the `product` repository.
 
-1. Add component as a submodule of product by running `git submodule add ../remote/component-repo.git/ include`.
+1. Add component as a submodule of product by running `git submodule add ../remote include`.
 2. What does your working directory look like?
 3. Does `git status` look like you expect?
 4. What if you cd to `include`?
@@ -54,7 +54,7 @@ Go to the `product` repository.
 Go to the `product_alpha` repository. We'll ensure that we have the latest changes from product.
 
 20. Run `git submodule update`.
-19. Is the latest change from `component` available in include?
+19. Is the latest change from `component` available in `include`?
 20. Examine the output of `git submodule status`. Compare the commit id with the `component` repository.
 21. Run `git submodule update --remote`.
 19. Is the latest change from `component` available in include?

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -1,36 +1,30 @@
-# First cleanup if there is an old exercise repository
+# First cleanup if there is an old exercise folder
 if (Test-Path .\exercise) {
-	Remove-Item .\exercise\ -force -recurse
+	Remove-Item .\exercise -force -recurse
 }
 
+# Create exercise folder & go there
 New-Item -ItemType Directory -Path exercise | Out-Null
-Set-Location .\exercise\
+Set-Location .\exercise
 
-# Create component repo
-New-Item -ItemType Directory -Path .\remote\component | Out-Null
-Set-Location .\remote\component
-git init
+# Create remote repo
+git init --bare remote
 
+# Clone it so that it is ready for the exercise
+git clone remote component
+
+# Commit a file to the component repo & push it to the remote
+Set-Location .\component
 Set-Content -Value "" -Path component.h
 git add component.h
 git commit -m "Touch component header"
-
-# Convert to a bare repository and delete the original working directory.
-Move-Item -Path ".git" -Destination ..\component-repo.git
-Set-Location ..\component-repo.git
-git config --bool core.bare true
-Set-Location ..
-Remove-Item -Path ./component -Force -Recurse
+git push
 Set-Location ..
 
-# And clone it so that it is ready for the exrcise.
-git clone remote/component-repo.git component
-
-# Create a product repository.
+# Create a product repo
 git init product
 Set-Location -Path .\product
 Set-Content -Value "" -Path .\product.h
 git add .\product.h
 git commit -m "Touch product header"
-
-Set-Location .\..
+Set-Location ..

--- a/submodules/setup.sh
+++ b/submodules/setup.sh
@@ -1,42 +1,36 @@
-#!/usr/bin/env bash
+#!/bin/bash
+kata="submodules"
 
-SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
-echo ${SCRIPT_PATH}
+# Include utils
+source ../utils/utils.sh
 
-EXERCISE_DIR=${SCRIPT_PATH}/exercise
+# First cleanup if there is an old exercise folder
+rm -rf exercise
 
-if [ -d ${EXERCISE_DIR} ]; then
-  rm -rf ${EXERCISE_DIR}
-fi
+# Create exercise folder & go there
+mkdir exercise
+cd exercise
 
-mkdir ${EXERCISE_DIR}
+# Create remote repo
+make-bare-remote-repo
 
-cd ${EXERCISE_DIR}
+# Clone it so that it is ready for the exercise
+git clone remote component
 
-# Create component repo
-mkdir -p remote/component
-git init remote/component
-cd remote/component
-
+# Commit a file to the component repo & push it to the remote
+cd component
 touch component.h
 git add component.h
 git commit -m "Touch component header"
-
-# Convert to a bare repository and delete the original working directory.
-mv .git ../component-repo.git
-cd ../component-repo.git
-git config --bool core.bare true
-cd ..
-rm -rf component/
+git push
 cd ..
 
-# And clone it so that it is ready for the exrcise.
-git clone remote/component-repo.git component
+# Create a product repo
+git init product
 
-# Create a product repository.
-mkdir product
+# Commit a file to the product repo
 cd product
-git init
 touch product.h
 git add product.h
-git commit -m "Touch product header."
+git commit -m "Touch product header"
+cd ..


### PR DESCRIPTION
- Use parts of the infrastructure in `../utils/`
- Sourcing (`. setup.sh`) or executing (`./setup.sh`) the script now both works
- Don't try to be smarter than the average setup.sh script if it doesn't work anyway...