### PR TITLE
Create GitHub actions CI pipeline for running test scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Run bash test scripts
       shell: bash
       run: |
-      chmod +x ./test.sh
-      ./test.sh
+        chmod +x ./test.sh
+        ./test.sh
 
   setup-pwsh:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Run bash test scripts
-      run: ./test.sh
       shell: bash
+      run: |
+      chmod +x ./test.sh
+      ./test.sh
 
   setup-pwsh:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  setup-bash:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run bash test scripts
+      run: ./test.sh
+      shell: bash
+
+jobs:
+  setup-pwsh:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run PowerShell Core test scripts
+      run: ./test.ps1
+      shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       run: ./test.sh
       shell: bash
 
-jobs:
   setup-pwsh:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,18 @@ jobs:
         chmod +x ./test.sh
         ./test.sh
 
+  setup-bash-macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run bash test scripts
+      shell: bash
+      run: |
+        chmod +x ./test.sh
+        ./test.sh
+
   setup-pwsh:
     runs-on: ubuntu-latest
 

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -36,6 +36,10 @@ git config --local user.name "git-katas trainer bot"
 git config --local user.email "git-katas@example.com"
 
 Set-Location -Path .\product
+
+git config --local user.name "git-katas trainer bot"
+git config --local user.email "git-katas@example.com"
+
 Set-Content -Value "" -Path .\product.h
 git add .\product.h
 git commit -m "Touch product header"

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -32,16 +32,13 @@ git clone remote/component-repo.git component
 # Create a product repository.
 git init product
 
-git config --local user.name "git-katas trainer bot"
-git config --local user.email "git-katas@example.com"
-
 Set-Location -Path .\product
 
 git config --local user.name "git-katas trainer bot"
 git config --local user.email "git-katas@example.com"
 
 Set-Content -Value "" -Path .\product.h
-git add .\product.h
+git add .
 git commit -m "Touch product header"
 
 Set-Location .\..

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -11,6 +11,9 @@ New-Item -ItemType Directory -Path .\remote\component | Out-Null
 Set-Location .\remote\component
 git init
 
+git config --local user.name "git-katas trainer bot"
+git config --local user.email "git-katas@example.com"
+
 Set-Content -Value "" -Path component.h
 git add component.h
 git commit -m "Touch component header"
@@ -28,6 +31,10 @@ git clone remote/component-repo.git component
 
 # Create a product repository.
 git init product
+
+git config --local user.name "git-katas trainer bot"
+git config --local user.email "git-katas@example.com"
+
 Set-Location -Path .\product
 Set-Content -Value "" -Path .\product.h
 git add .\product.h

--- a/test.ps1
+++ b/test.ps1
@@ -1,3 +1,5 @@
-cd basic-commits
+Push-Location basic-commits
+
 .\setup.ps1
-cd ..
+
+Pop-Location

--- a/test.ps1
+++ b/test.ps1
@@ -1,5 +1,10 @@
-Push-Location basic-commits
-
-.\setup.ps1
-
-Pop-Location
+Get-ChildItem -Attributes Directory |
+  ForEach-Object {
+    if ($(Get-ChildItem $_.Name setup.ps1))
+    {
+      Push-Location $_.Name
+      Write-Output "`nRunning setup script for kata $($_.Name)"
+      .\setup.ps1
+      Pop-Location
+    }
+  }


### PR DESCRIPTION
This GitHub Actions workflow will run `test.sh` and `test.ps1` scripts upon pushes and pull requests on Linux, MacOS and Windows (PowerShell Core).
The `test.ps1` is extended to go through all katas that have a `setup.ps1` file.
During the workflow creation I found a small issue in the submodules kata that failed the workflow, this was also corrected (although this may conflict with PR #258).

TODO: Make `test.sh` also go through all katas where applicable.

Resolves: #154