### PR TITLE
Gracefully fail when removing exercises folder in PowerShell setup scripts

### DIFF
--- a/utils/make-exercise-repo.ps1
+++ b/utils/make-exercise-repo.ps1
@@ -1,6 +1,6 @@
 # First cleanup if there is an old exercise repository
 if (Test-Path .\exercise) {
-	Remove-Item .\exercise\ -force -recurse
+	Remove-Item .\exercise\ -Force -Recurse -ErrorAction:Stop
 }
 
 # Initialize a new repository

--- a/utils/make-exercise-repo.ps1
+++ b/utils/make-exercise-repo.ps1
@@ -1,15 +1,24 @@
 # First cleanup if there is an old exercise repository
-if (Test-Path .\exercise) {
-	Remove-Item .\exercise\ -Force -Recurse -ErrorAction:Stop
+try {
+	if (Test-Path .\exercise) {
+		Remove-Item .\exercise\ -Force -Recurse -ErrorAction:Stop
+	}
+
+	# Initialize a new repository
+	git init exercise
+
+	# Go there
+	Set-Location .\exercise\
+
+	# Using this as a check if the exercise folder was created successfully
+	# If there was an issue during git init the Get-ChildItem will fail
+	$null = Get-ChildItem .  -ErrorAction:Stop
+
+	# Set local git user name and email to distinguish commits.
+	git config --local user.name "git-katas trainer bot"
+	git config --local user.email "git-katas@example.com"
 }
-
-# Initialize a new repository
-git init exercise
-
-# Go there
-Set-Location .\exercise\
-
-# Set local git user name and email to distinguish commits.
-git config --local user.name "git-katas trainer bot"
-git config --local user.email "git-katas@example.com"
+catch {
+	Write-Error "Error during exercise creation`nPlease try removing the exercise folder manually and run setup.ps1 again."
+}
 


### PR DESCRIPTION
If for whatever reason the `exercises` folder cannot be removed the `setup.ps1` script did not stop but continue running potentionally spilling a lot of error messages.
With this change the failing deletion will stop the setup script.

Resolves: #243